### PR TITLE
Apply robinhood font style to site

### DIFF
--- a/app/fonts.ts
+++ b/app/fonts.ts
@@ -1,10 +1,10 @@
 import localFont from 'next/font/local';
 
-// Load ITC Garamond Std font locally
-export const itcGaramond = localFont({
-  src: './fonts/itc-garamond-std.otf',
+// Example: If we later want to expose CSS variables via next/font, we can define them here.
+// Not used currently because we rely on CSS variables set in app/globals.css.
+
+export const unused = localFont({
+  src: '../public/itc-garamond-std.otf',
   display: 'swap',
   variable: '--font-itc-garamond',
 });
-
-// Define other fonts as needed

--- a/app/globals.css
+++ b/app/globals.css
@@ -81,7 +81,7 @@
     /* ===== TYPOGRAPHY TOKENS ===== */
     
     /* Font Families */
-    --font-family-display: 'ITC Garamond Std', Georgia, 'Times New Roman', serif;
+    --font-family-display: 'Styrene B', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     --font-family-body: 'Styrene B', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     --font-family-serif: 'Tiempos Text', Georgia, 'Times New Roman', serif;
     
@@ -240,6 +240,12 @@
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     text-rendering: optimizeLegibility;
+  }
+
+  h1, h2, h3, h4, h5, h6 {
+    font-family: var(--font-family-display);
+    font-weight: var(--font-weight-medium);
+    letter-spacing: var(--letter-spacing-tight);
   }
   
   /* Selection styling - Anthropic exact */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,7 +4,6 @@ import { StructuredData, organizationSchema } from '@/components/structured-data
 import { Toaster } from '@/components/toaster'
 import { Providers } from '@/lib/providers'
 import type { Metadata, Viewport } from 'next'
-import { itcGaramond } from './fonts'
 import './globals.css'
 
 export const viewport: Viewport = {
@@ -86,10 +85,10 @@ export default function RootLayout({ children }: RootLayoutProps) {
         <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
         <link rel="manifest" href="/manifest.json" />
         {/* Preload critical fonts */}
-        <link rel="preload" href="/itc-garamond-std.otf" as="font" type="font/otf" crossOrigin="anonymous" />
+        <link rel="preload" href="/__styreneB_57fc85-normal-500-100.ttf" as="font" type="font/ttf" crossOrigin="anonymous" />
         <link rel="preload" href="/__styreneB_57fc85-normal-400-100.ttf" as="font" type="font/ttf" crossOrigin="anonymous" />
       </head>
-      <body className={`min-h-screen bg-background font-sans antialiased ${itcGaramond.variable}`}>
+      <body className={`min-h-screen bg-background font-sans antialiased`}>
         <Providers>
           <StructuredData data={organizationSchema} />
           <div className="relative flex min-h-screen flex-col">

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -63,7 +63,8 @@ const config: Config = {
         },
       },
       fontFamily: {
-        sans: ["Inter", "system-ui", "sans-serif"],
+        sans: ["var(--font-family-body)"],
+        serif: ["var(--font-family-serif)"],
         mono: ["JetBrains Mono", "monospace"],
       },
       fontSize: {


### PR DESCRIPTION
Implement a site-wide font system resembling Robinhood.com's typography.

---
<a href="https://cursor.com/background-agent?bcId=bc-17065a1b-154a-4d60-989c-38575bee4f48">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-17065a1b-154a-4d60-989c-38575bee4f48">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

